### PR TITLE
Fix joint value reported for prismatic axis

### DIFF
--- a/include/abb_libegm/egm_common.h
+++ b/include/abb_libegm/egm_common.h
@@ -100,6 +100,17 @@ struct Constants
      * \brief Maximum number of joints.
      */
     static const int MAX_NUMBER_OF_JOINTS;
+
+    /**
+     * \brief The index of the prismatic joint if present
+     */
+    static const int INDEX_OF_PRISMATIC_JOINT;
+
+      /**
+     * \brief The z coordinate of the end-effector when the prismatic joint is
+     *  at its minimum value. Measured in mm.
+     */
+    static const double Z_AXIS_OFFSET_FOR_FOUR_AXIS_ROBOT;
   };
 
   /**

--- a/src/egm_common.cpp
+++ b/src/egm_common.cpp
@@ -56,6 +56,8 @@ const int RobotController::DEFAULT_NUMBER_OF_ROBOT_JOINTS = 6;
 const int RobotController::DEFAULT_NUMBER_OF_EXTERNAL_JOINTS = 6;
 const int RobotController::MAX_NUMBER_OF_JOINTS = RobotController::DEFAULT_NUMBER_OF_ROBOT_JOINTS +
                                                   RobotController::DEFAULT_NUMBER_OF_EXTERNAL_JOINTS;
+const int RobotController::INDEX_OF_PRISMATIC_JOINT = 2;
+const double RobotController::Z_AXIS_OFFSET_FOR_FOUR_AXIS_ROBOT = 220.2; // ABB IRB910SC
 
 const double Constants::Conversion::RAD_TO_DEG = 180.0 / M_PI;
 const double Constants::Conversion::DEG_TO_RAD = M_PI / 180.0;

--- a/src/egm_common_auxiliary.cpp
+++ b/src/egm_common_auxiliary.cpp
@@ -41,6 +41,7 @@
 #include <boost/math/quaternion.hpp>
 
 #include "abb_libegm/egm_common_auxiliary.h"
+#include "abb_libegm/egm_common.h"
 
 namespace abb
 {
@@ -889,8 +890,8 @@ bool parse(wrapper::Feedback* p_target, const EgmFeedBack& source, const RobotAx
           if (source.has_cartesian())
           {
             auto mutable_values = p_target->mutable_robot()->mutable_joints()->mutable_position()->mutable_values();
-            auto& val = mutable_values->at(2);
-            val = source.cartesian().pos().z() - 220.2;
+            auto& val = mutable_values->at(Constants::RobotController::INDEX_OF_PRISMATIC_JOINT);
+            val = source.cartesian().pos().z() - Constants::RobotController::Z_AXIS_OFFSET_FOR_FOUR_AXIS_ROBOT;
           }
           else
           {

--- a/src/egm_common_auxiliary.cpp
+++ b/src/egm_common_auxiliary.cpp
@@ -866,20 +866,6 @@ bool parse(wrapper::Feedback* p_target, const EgmFeedBack& source, const RobotAx
 {
   bool success = false;
 
-  std::cout << "EGMFeedback joints: ";
-  for (const auto& j : source.joints().joints())
-    std::cout << j << ",";
-  std::cout << std::endl;
-
-  // std::cout << "EGMFeedback external joints: ";
-  // for (const auto& j : source.externalJoints().joints())
-  //   std::cout << j << ",";
-  // std::cout << std::endl;
-
-  std::cout << "EGMFeedback pose: " << source.cartesian().pos().x() << ","
-            << source.cartesian().pos().y() << ","
-            << source.cartesian().pos().z() << std::endl;
-
   if (p_target)
   {
     success = parse(p_target->mutable_robot()->mutable_joints()->mutable_position(),

--- a/src/egm_controller_interface.cpp
+++ b/src/egm_controller_interface.cpp
@@ -119,16 +119,6 @@ void EGMControllerInterface::ControllerMotion::readInputs(wrapper::Input* p_inpu
 {
   boost::lock_guard<boost::mutex> lock(read_mutex_);
 
-  std::cout << "### [ControllerMotion::readInputs()] ###" << std::endl;
-  std::cout << "Feedback: " << std::endl;
-  const auto& joint_space = inputs_.feedback().robot().joints();
-  const auto& cartesian_space = inputs_.feedback().robot().cartesian();
-  std::cout << "Positions: [";
-  for (const auto& p : joint_space.position().values())
-  {
-    std::cout << p << ",";
-  }
-  std::cout << "]" << std::endl;
   p_inputs->CopyFrom(inputs_);
   read_data_ready_ = false;
 }

--- a/src/egm_controller_interface.cpp
+++ b/src/egm_controller_interface.cpp
@@ -119,6 +119,16 @@ void EGMControllerInterface::ControllerMotion::readInputs(wrapper::Input* p_inpu
 {
   boost::lock_guard<boost::mutex> lock(read_mutex_);
 
+  std::cout << "### [ControllerMotion::readInputs()] ###" << std::endl;
+  std::cout << "Feedback: " << std::endl;
+  const auto& joint_space = inputs_.feedback().robot().joints();
+  const auto& cartesian_space = inputs_.feedback().robot().cartesian();
+  std::cout << "Positions: [";
+  for (const auto& p : joint_space.position().values())
+  {
+    std::cout << p << ",";
+  }
+  std::cout << "]" << std::endl;
   p_inputs->CopyFrom(inputs_);
   read_data_ready_ = false;
 }


### PR DESCRIPTION
As reported [here](https://github.com/ros-industrial/abb_libegm/pull/142#issuecomment-1198073818), the joint value of the prismatic joint is not properly reported by the robot EGM client.

This PR updates the protobuf parsing to compensate for this error by deriving the correct value from the cartesian Z-value of the robot.